### PR TITLE
Cacheable tipi deps

### DIFF
--- a/.tipi/deps
+++ b/.tipi/deps
@@ -1,11 +1,9 @@
 { 
   "ikalnitsky/termcolor" : { "@" : "v2.0.0" },
-  "tipi-deps/boost" : {
-      "id" : {"host_name":"github.com","org_name":"lambourl","repo_name":"boost"}
-    , "@" : "v1.80.0-without-submodules"
-    , "u" : true
-    , "opts" : "set(BOOST_INCLUDE_LIBRARIES system filesystem)"
-    , "packages" : ["boost_system", "boost_filesystem"]
-    , "targets" : ["Boost::system", "Boost::filesystem"]
-  }
+  "boostorg/boost" : { "@" : "boost-1.80.0",
+    "opts": "set(BOOST_INCLUDE_LIBRARIES system filesystem uuid)",
+    "packages": [ "boost_system", "boost_filesystem", "boost_uuid" ],
+    "targets": [ "Boost::system", "Boost::filesystem", "Boost::uuid" ],
+    "u": true
+  } 
 }

--- a/.tipi/deps
+++ b/.tipi/deps
@@ -1,4 +1,9 @@
 { 
   "ikalnitsky/termcolor" : { "@" : "v2.0.0" },
-  "platform" : ["Boost::system", "Boost::filesystem"]
+  "tipi-deps/boost" : {
+    "@" : "v1.80.0-without-submodules"
+    , "u" : true
+    , "packages" : ["boost_system", "boost_filesystem"]
+    , "targets" : ["Boost::system", "Boost::filesystem"]
+  }
 }

--- a/.tipi/deps
+++ b/.tipi/deps
@@ -1,8 +1,10 @@
 { 
   "ikalnitsky/termcolor" : { "@" : "v2.0.0" },
   "tipi-deps/boost" : {
-    "@" : "v1.80.0-without-submodules"
+      "id" : {"host_name":"github.com","org_name":"lambourl","repo_name":"boost"}
+    , "@" : "v1.80.0-without-submodules"
     , "u" : true
+    , "opts" : "set(BOOST_INCLUDE_LIBRARIES system filesystem)"
     , "packages" : ["boost_system", "boost_filesystem"]
     , "targets" : ["Boost::system", "Boost::filesystem"]
   }

--- a/.tipi/id
+++ b/.tipi/id
@@ -1,0 +1,1 @@
+{"host_name":"github.com","org_name":"nxxm","repo_name":"cli_widgets"}


### PR DESCRIPTION
Changes to tipi deps file to build only with cacheable dependencies (no platform libs anymore)